### PR TITLE
Fix issues loading INDD plugin on LTS 2019 (10.10) HF54

### DIFF
--- a/nuxeo-indd-rendition-core/src/main/java/org/nuxeo/labs/indd/rendition/service/InDesignRenditionServiceImpl.java
+++ b/nuxeo-indd-rendition-core/src/main/java/org/nuxeo/labs/indd/rendition/service/InDesignRenditionServiceImpl.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.pdfbox.exceptions.COSVisitorException;
 import org.nuxeo.ecm.automation.core.util.BlobList;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.CloseableFile;
@@ -54,20 +53,6 @@ public class InDesignRenditionServiceImpl extends DefaultComponent implements In
     @Override
     public void deactivate(ComponentContext context) {
         super.deactivate(context);
-    }
-
-    /**
-     * Application started notification.
-     * Called after the application started.
-     * You can do here any initialization that requires a working application
-     * (all resolved bundles and components are active at that moment)
-     *
-     * @param context the component context. Use it to get the current bundle context
-     * @throws Exception
-     */
-    @Override
-    public void applicationStarted(ComponentContext context) {
-        // do nothing by default. You can remove this method if not used.
     }
 
     @Override
@@ -150,7 +135,7 @@ public class InDesignRenditionServiceImpl extends DefaultComponent implements In
 
         try {
             return merger.merge("preview.pdf");
-        } catch (COSVisitorException | IOException e) {
+        } catch (IOException e) {
             throw new NuxeoException(e);
         }
     }

--- a/nuxeo-indd-rendition-package/src/main/resources/package.xml
+++ b/nuxeo-indd-rendition-package/src/main/resources/package.xml
@@ -18,6 +18,9 @@
     <platform>server-@DISTRIB_VERSION@-HF*</platform>
   </platforms>
   <!-- Dependencies on other packages -->
+  <dependencies>
+    <package>nuxeo-10.10-HF54:1.0.0</package>
+  </dependencies>
   <!-- <dependencies> -->
   <!-- <package>another-package:1.0.0:1.0.0</package> -->
   <!-- If you require JSF UI package:  -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ecm.distribution</groupId>
     <artifactId>nuxeo-distribution</artifactId>
-    <version>10.10</version>
+    <version>10.10-HF54</version>
   </parent>
 
   <groupId>org.nuxeo.labs.indd.rendition</groupId>


### PR DESCRIPTION
I discovered this issue when trying to use the PCLM plugin with HF54. Turns out that the INDD Rendition plugin gets pulled in when PCLM is installed.

Error On Boot:

```
2021-11-11T11:17:19,061 ERROR [[/nuxeo]] Exception sending context initialized event to listener instance of class [org.nuxeo.runtime.deployment.NuxeoStarter]
java.lang.NoClassDefFoundError: org/apache/pdfbox/exceptions/COSVisitorException
        at java.lang.Class.getDeclaredConstructors0(Native Method) ~[?:?]
        at java.lang.Class.privateGetDeclaredConstructors(Class.java:3137) ~[?:?]
        at java.lang.Class.getConstructor0(Class.java:3342) ~[?:?]
        at java.lang.Class.newInstance(Class.java:556) ~[?:?]
        at org.nuxeo.runtime.model.impl.ComponentInstanceImpl.createInstance(ComponentInstanceImpl.java:89) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.model.impl.ComponentInstanceImpl.<init>(ComponentInstanceImpl.java:68) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.model.impl.RegistrationInfoImpl.createComponentInstance(RegistrationInfoImpl.java:340) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.model.impl.RegistrationInfoImpl.activate(RegistrationInfoImpl.java:422) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.model.impl.ComponentManagerImpl.activateComponent(ComponentManagerImpl.java:554) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.model.impl.ComponentManagerImpl.activateComponents(ComponentManagerImpl.java:533) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.model.impl.ComponentManagerImpl.start(ComponentManagerImpl.java:795) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.osgi.OSGiRuntimeService.startComponents(OSGiRuntimeService.java:447) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.runtime.osgi.OSGiRuntimeService.frameworkEvent(OSGiRuntimeService.java:462) ~[nuxeo-runtime-10.10-HF45.jar:?]
        at org.nuxeo.osgi.OSGiAdapter.fireFrameworkEvent(OSGiAdapter.java:223) ~[nuxeo-runtime-osgi-10.10-HF52.jar:?]
        at org.nuxeo.osgi.application.loader.FrameworkLoader.doStart(FrameworkLoader.java:226) ~[nuxeo-runtime-osgi-10.10-HF52.jar:?]
        at org.nuxeo.osgi.application.loader.FrameworkLoader.start(FrameworkLoader.java:125) ~[nuxeo-runtime-osgi-10.10-HF52.jar:?]
        at org.nuxeo.runtime.deployment.NuxeoStarter.start(NuxeoStarter.java:124) ~[nuxeo-runtime-deploy-10.10.jar:?]
        at org.nuxeo.runtime.deployment.NuxeoStarter.contextInitialized(NuxeoStarter.java:93) ~[nuxeo-runtime-deploy-10.10.jar:?]
        at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4768) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5230) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:726) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:698) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:696) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.startup.HostConfig.deployDescriptor(HostConfig.java:690) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.startup.HostConfig$DeployDescriptor.run(HostConfig.java:1889) [catalina-9.0.54.jar:9.0.54]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75) [tomcat-util-9.0.54.jar:9.0.54]
        at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:118) [?:?]
        at org.apache.catalina.startup.HostConfig.deployDescriptors(HostConfig.java:583) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.startup.HostConfig.deployApps(HostConfig.java:473) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.startup.HostConfig.start(HostConfig.java:1618) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.startup.HostConfig.lifecycleEvent(HostConfig.java:319) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:423) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.setState(LifecycleBase.java:366) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:946) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:835) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1396) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1386) [catalina-9.0.54.jar:9.0.54]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75) [tomcat-util-9.0.54.jar:9.0.54]
        at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:140) [?:?]
        at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:919) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.StandardEngine.startInternal(StandardEngine.java:263) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.StandardService.startInternal(StandardService.java:432) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.core.StandardServer.startInternal(StandardServer.java:927) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) [catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.startup.Catalina.start(Catalina.java:772) [catalina-9.0.54.jar:9.0.54]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.apache.catalina.startup.Bootstrap.start(Bootstrap.java:345) [bootstrap-9.0.54.jar:9.0.54]
        at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:476) [bootstrap-9.0.54.jar:9.0.54]
Caused by: java.lang.ClassNotFoundException: org.apache.pdfbox.exceptions.COSVisitorException
        at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1407) ~[catalina-9.0.54.jar:9.0.54]
        at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1215) ~[catalina-9.0.54.jar:9.0.54]
        ... 59 more
```

Might be a good idea to merge this into a new 10.10 branch 😉

Thanks!
Robert Rick